### PR TITLE
correzione errore di battitura

### DIFF
--- a/data15.js
+++ b/data15.js
@@ -148,7 +148,7 @@ const gData15 = [
     {
 		nome: 'Giuliano A',
 		'satoshi/€': 684,
-		'telegram-id': '@giulianoassoggio'
+		'telegram-id': '@giulianoassaggio'
 	},
     {
 		nome: 'Account Eliminato',


### PR DESCRIPTION
Come da titolo. ero tentato di scrivere `fix typo`, ma la lingua italiana è in grado di esprimere il concetto ugualmente, se non meglio 